### PR TITLE
xcode 26 updates

### DIFF
--- a/Metadata.txt
+++ b/Metadata.txt
@@ -8,7 +8,7 @@ Support URL: https://support.iconfactory.com
 
 Marketing URL: https://iconfactoryapps.com
 
-Copyright: © 2009-2020 Manolo Sañudo
+Copyright: © 2009-2025 Manolo Sañudo
 
 Description:
 

--- a/xFonts.xcodeproj/project.pbxproj
+++ b/xFonts.xcodeproj/project.pbxproj
@@ -494,7 +494,7 @@
 					93AE4C671E42C44B00D19E41 = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = CLD83938CC;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -778,8 +778,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = CLD83938CC;
 				INFOPLIST_FILE = xFonts/Info.plist;
@@ -788,7 +788,7 @@
 				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.manolosavi.xFonts;
 				PRODUCT_NAME = Fontcase;
-				PROVISIONING_PROFILE_SPECIFIER = "xFonts App Store";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -797,8 +797,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = CLD83938CC;
 				INFOPLIST_FILE = xFonts/Info.plist;
@@ -807,7 +807,7 @@
 				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.manolosavi.xFonts;
 				PRODUCT_NAME = Fontcase;
-				PROVISIONING_PROFILE_SPECIFIER = "xFonts App Store";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/xFonts.xcodeproj/project.pbxproj
+++ b/xFonts.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		9309F3791E4917B2002F2AB7 /* RoutingConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 9309F34E1E4917B2002F2AB7 /* RoutingConnection.m */; };
 		9309F37A1E4917B2002F2AB7 /* RoutingHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9309F3501E4917B2002F2AB7 /* RoutingHTTPServer.m */; };
 		93320FD61E4EACCC0045C38C /* index.html in Resources */ = {isa = PBXBuildFile; fileRef = 93320FD51E4EACCB0045C38C /* index.html */; };
+		937C0F252E7F9BF0000832F6 /* HelpOverlayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 937C0F242E7F9BF0000832F6 /* HelpOverlayViewController.m */; };
 		93AE4C6D1E42C44B00D19E41 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 93AE4C6C1E42C44B00D19E41 /* main.m */; };
 		93AE4C701E42C44B00D19E41 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 93AE4C6F1E42C44B00D19E41 /* AppDelegate.m */; };
 		93AE4C731E42C44B00D19E41 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 93AE4C721E42C44B00D19E41 /* ViewController.m */; };
@@ -175,6 +176,8 @@
 		9309F34F1E4917B2002F2AB7 /* RoutingHTTPServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RoutingHTTPServer.h; sourceTree = "<group>"; };
 		9309F3501E4917B2002F2AB7 /* RoutingHTTPServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RoutingHTTPServer.m; sourceTree = "<group>"; };
 		93320FD51E4EACCB0045C38C /* index.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = index.html; sourceTree = "<group>"; };
+		937C0F232E7F9BF0000832F6 /* HelpOverlayViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HelpOverlayViewController.h; sourceTree = "<group>"; };
+		937C0F242E7F9BF0000832F6 /* HelpOverlayViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HelpOverlayViewController.m; sourceTree = "<group>"; };
 		93AE4C681E42C44B00D19E41 /* Fontcase.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Fontcase.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		93AE4C6C1E42C44B00D19E41 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		93AE4C6E1E42C44B00D19E41 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -430,6 +433,8 @@
 				443576C7244CDC3800669EEB /* AboutViewController.m */,
 				443576D32450AE4200669EEB /* HelpViewController.h */,
 				443576D42450AE4200669EEB /* HelpViewController.m */,
+				937C0F232E7F9BF0000832F6 /* HelpOverlayViewController.h */,
+				937C0F242E7F9BF0000832F6 /* HelpOverlayViewController.m */,
 				449C16812450B1D90070226F /* Help.md */,
 				44A20B022447DC4100BF15DA /* FontInfo.h */,
 				44A20B032447DC4100BF15DA /* FontInfo.m */,
@@ -590,6 +595,7 @@
 				9309F37A1E4917B2002F2AB7 /* RoutingHTTPServer.m in Sources */,
 				93AE4C701E42C44B00D19E41 /* AppDelegate.m in Sources */,
 				9309F3761E4917B2002F2AB7 /* Route.m in Sources */,
+				937C0F252E7F9BF0000832F6 /* HelpOverlayViewController.m in Sources */,
 				9309F3711E4917B2002F2AB7 /* DispatchQueueLogFormatter.m in Sources */,
 				44C12221244A8F3F00DD9481 /* NavigationController.m in Sources */,
 				9309F35E1E4917B2002F2AB7 /* HTTPErrorResponse.m in Sources */,
@@ -646,6 +652,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -654,6 +661,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/xFonts/AboutViewController.m
+++ b/xFonts/AboutViewController.m
@@ -11,6 +11,7 @@
 @interface AboutViewController ()
 
 @property (nonatomic, weak) IBOutlet UILabel *versionLabel;
+@property (nonatomic, weak) IBOutlet UIView *tabBarBackgroundView;
 
 @end
 
@@ -23,6 +24,12 @@
 	NSString *productVersion = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
 	NSString *productBuild = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleVersion"];
 	self.versionLabel.text = [NSString stringWithFormat:@"VERSION %@ (%@)", productVersion, productBuild];
+	
+	if (@available(iOS 26.0, *)) { // only need to add a bg color before iOS 26
+		[self.tabBarBackgroundView setHidden:YES];
+	} else {
+		[self.tabBarBackgroundView setHidden:NO];
+	}
 }
 
 - (IBAction)openIconfactory:(id)sender

--- a/xFonts/Assets.xcassets/Colors/appHeaderText.colorset/Contents.json
+++ b/xFonts/Assets.xcassets/Colors/appHeaderText.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0xEC",
-          "red" : "0xF1"
+          "blue" : "0xBA",
+          "green" : "0x5B",
+          "red" : "0x77"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0xEC",
-          "red" : "0xF1"
+          "blue" : "0xDD",
+          "green" : "0x86",
+          "red" : "0xA0"
         }
       },
       "idiom" : "universal"

--- a/xFonts/Base.lproj/Main.storyboard
+++ b/xFonts/Base.lproj/Main.storyboard
@@ -255,7 +255,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="t9v-2L-JtN">
-                                        <rect key="frame" x="0.0" y="20" width="414" height="757.5"/>
+                                        <rect key="frame" x="0.0" y="20" width="414" height="801.5"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7cn-Q4-QXT">
                                                 <rect key="frame" x="20" y="0.0" width="374" height="40"/>
@@ -336,14 +336,14 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="tRH-wl-eJ4">
                                                 <rect key="frame" x="20" y="352.5" width="374" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="File Name" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7fK-Pn-QLd">
-                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" text="File Name" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7fK-Pn-QLd">
+                                                        <rect key="frame" x="0.0" y="0.0" width="134" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MyFont.ttf" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6zX-ej-UMU">
-                                                        <rect key="frame" x="89" y="0.0" width="285" height="20.5"/>
+                                                        <rect key="frame" x="144" y="0.0" width="230" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -353,14 +353,14 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Q2A-2U-RUA">
                                                 <rect key="frame" x="20" y="383" width="374" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="PostScript Name" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AzZ-Uv-yGl">
-                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" text="PostScript Name" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AzZ-Uv-yGl">
+                                                        <rect key="frame" x="0.0" y="0.0" width="134" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MyFont-Regular" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aNI-lC-f2f">
-                                                        <rect key="frame" x="89" y="0.0" width="285" height="20.5"/>
+                                                        <rect key="frame" x="144" y="0.0" width="230" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -370,14 +370,14 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ByW-aB-TAa">
                                                 <rect key="frame" x="20" y="413.5" width="374" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="Full Name" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5GB-6w-QAj">
-                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" text="Full Name" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5GB-6w-QAj">
+                                                        <rect key="frame" x="0.0" y="0.0" width="134" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="My Font Regular" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gDe-ex-bBn">
-                                                        <rect key="frame" x="89" y="0.0" width="285" height="20.5"/>
+                                                        <rect key="frame" x="144" y="0.0" width="230" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -387,14 +387,14 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="dgS-iv-AKS">
                                                 <rect key="frame" x="20" y="444" width="374" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="Family" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="esG-gg-dKM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" text="Family" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="esG-gg-dKM">
+                                                        <rect key="frame" x="0.0" y="0.0" width="134" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="My Font" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7FM-tz-szw">
-                                                        <rect key="frame" x="89" y="0.0" width="285" height="20.5"/>
+                                                        <rect key="frame" x="144" y="0.0" width="230" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -404,14 +404,14 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Uoq-hu-Ykv">
                                                 <rect key="frame" x="20" y="474.5" width="374" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="Style" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bhU-gW-MFj">
-                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" text="Style" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bhU-gW-MFj">
+                                                        <rect key="frame" x="0.0" y="0.0" width="134" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Regular" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="az5-rx-TYU">
-                                                        <rect key="frame" x="89" y="0.0" width="285" height="20.5"/>
+                                                        <rect key="frame" x="144" y="0.0" width="230" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -421,14 +421,14 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="NsI-oH-WFX">
                                                 <rect key="frame" x="20" y="505" width="374" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="Monospaced" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i3h-tF-FFh">
-                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" text="Monospaced" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i3h-tF-FFh">
+                                                        <rect key="frame" x="0.0" y="0.0" width="134" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HsY-i3-sNc">
-                                                        <rect key="frame" x="89" y="0.0" width="285" height="20.5"/>
+                                                        <rect key="frame" x="144" y="0.0" width="230" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -438,14 +438,14 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ztu-Tg-fgU">
                                                 <rect key="frame" x="20" y="535.5" width="374" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="Glyph Count" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DOi-Ta-eJi">
-                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" text="Glyph Count" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DOi-Ta-eJi">
+                                                        <rect key="frame" x="0.0" y="0.0" width="134" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1,234" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rDj-RZ-xi1">
-                                                        <rect key="frame" x="89" y="0.0" width="285" height="20.5"/>
+                                                        <rect key="frame" x="144" y="0.0" width="230" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -455,14 +455,14 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ghc-LA-n3v">
                                                 <rect key="frame" x="20" y="566" width="374" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="Version" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gXQ-TC-9Rw">
-                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" text="Version" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gXQ-TC-9Rw">
+                                                        <rect key="frame" x="0.0" y="0.0" width="134" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1.0a1" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nSd-dV-SL4">
-                                                        <rect key="frame" x="89" y="0.0" width="285" height="20.5"/>
+                                                        <rect key="frame" x="144" y="0.0" width="230" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -472,14 +472,14 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="qkb-Qg-nVx">
                                                 <rect key="frame" x="20" y="596.5" width="374" height="42.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="Copyright" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b0l-a4-B57">
-                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" text="Copyright" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b0l-a4-B57">
+                                                        <rect key="frame" x="0.0" y="0.0" width="134" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="© Some Company with a Long Name, Inc." textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Has-Tl-Ky7">
-                                                        <rect key="frame" x="89" y="0.0" width="285" height="42.5"/>
+                                                        <rect key="frame" x="144" y="0.0" width="230" height="42.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -487,16 +487,16 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="era-WV-WYr">
-                                                <rect key="frame" x="20" y="649" width="374" height="108.5"/>
+                                                <rect key="frame" x="20" y="649" width="374" height="152.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Description" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kVe-yk-J3E">
-                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalCompressionResistancePriority="1000" text="Description" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kVe-yk-J3E">
+                                                        <rect key="frame" x="0.0" y="0.0" width="134" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eYp-bL-u5D">
-                                                        <rect key="frame" x="89" y="0.0" width="285" height="108.5"/>
+                                                        <rect key="frame" x="144" y="0.0" width="230" height="152.5"/>
                                                         <string key="text">This is going to either be really short (or non-existant) or a fricken' tomb on the font's history. It all depends on the foundary and the motivations behind the designers.</string>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>

--- a/xFonts/Base.lproj/Main.storyboard
+++ b/xFonts/Base.lproj/Main.storyboard
@@ -1,23 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qyC-eK-c3T">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24127" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qyC-eK-c3T">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24063"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Help Overlay View Controller-->
         <scene sceneID="5oP-de-wu2">
             <objects>
-                <viewController id="teL-20-r1o" sceneMemberID="viewController">
+                <viewController id="teL-20-r1o" customClass="HelpOverlayViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="2Oq-8v-pYO">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xY3-y1-AGm">
-                                <rect key="frame" x="175" y="563.5" width="64" height="41"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xY3-y1-AGm">
+                                <rect key="frame" x="175" y="565.5" width="64" height="41"/>
                                 <color key="backgroundColor" name="infoHighlight"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <inset key="contentEdgeInsets" minX="20" minY="10" maxX="20" maxY="10"/>
@@ -32,7 +34,7 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DBs-rs-jpm" userLabel="Step 1">
-                                <rect key="frame" x="38" y="383" width="159" height="140.5"/>
+                                <rect key="frame" x="38" y="385" width="159" height="140.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="o9q-DP-1EZ">
                                         <rect key="frame" x="10" y="10" width="13" height="29"/>
@@ -59,7 +61,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kf3-2W-iS0" userLabel="Step 2">
-                                <rect key="frame" x="217" y="383" width="159" height="140.5"/>
+                                <rect key="frame" x="217" y="385" width="159" height="140.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WjT-Gr-UZ7">
                                         <rect key="frame" x="133" y="10" width="16" height="29"/>
@@ -86,7 +88,7 @@
                                 </constraints>
                             </view>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="arrowhead" translatesAutoresizingMaskIntoConstraints="NO" id="8HT-fj-P4R" userLabel="Left Point">
-                                <rect key="frame" x="33" y="82" width="12" height="12"/>
+                                <rect key="frame" x="33" y="86" width="12" height="12"/>
                                 <color key="tintColor" name="infoHighlight"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="12" id="cxP-Mq-H6V"/>
@@ -94,14 +96,14 @@
                                 </constraints>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HpR-br-pgM" userLabel="Left Connector">
-                                <rect key="frame" x="38" y="94" width="2" height="429.5"/>
+                                <rect key="frame" x="38" y="98" width="2" height="427.5"/>
                                 <color key="backgroundColor" name="statusTextSecondary"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="2" id="gQv-yc-pzn"/>
                                 </constraints>
                             </view>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="arrowhead" translatesAutoresizingMaskIntoConstraints="NO" id="xXW-Oe-Wds" userLabel="Right Point">
-                                <rect key="frame" x="369" y="82" width="12" height="12"/>
+                                <rect key="frame" x="369" y="86" width="12" height="12"/>
                                 <color key="tintColor" name="infoHighlight"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="12" id="J2n-SF-lrv"/>
@@ -109,7 +111,7 @@
                                 </constraints>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4zL-Sb-Fay" userLabel="Right Connector">
-                                <rect key="frame" x="374" y="94" width="2" height="429.5"/>
+                                <rect key="frame" x="374" y="98" width="2" height="427.5"/>
                                 <color key="backgroundColor" name="statusTextSecondary"/>
                                 <color key="tintColor" name="statusTextSecondary"/>
                                 <constraints>
@@ -117,6 +119,7 @@
                                 </constraints>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="z8X-iI-BEB"/>
                         <color key="backgroundColor" name="overlayBackground"/>
                         <constraints>
                             <constraint firstItem="xXW-Oe-Wds" firstAttribute="centerY" secondItem="z8X-iI-BEB" secondAttribute="top" constant="44" id="2Ae-v8-HJ6"/>
@@ -139,10 +142,12 @@
                             <constraint firstItem="DBs-rs-jpm" firstAttribute="centerY" secondItem="z8X-iI-BEB" secondAttribute="centerY" id="vPs-v2-6Jt"/>
                             <constraint firstItem="xY3-y1-AGm" firstAttribute="top" secondItem="kf3-2W-iS0" secondAttribute="bottom" constant="40" id="xRf-Nq-lXo"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="z8X-iI-BEB"/>
                     </view>
                     <nil key="simulatedTopBarMetrics"/>
                     <nil key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="okButton" destination="xY3-y1-AGm" id="EUe-3B-dKf"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gEe-pz-W5C" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <exit id="fWI-9F-bIw" userLabel="Exit" sceneMemberID="exit"/>
@@ -154,9 +159,9 @@
             <objects>
                 <tableViewController title="Fonts" id="FOw-fU-3BX" customClass="ViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="yyv-FH-WXJ">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <view key="tableHeaderView" contentMode="scaleToFill" id="fEz-pn-Q2A" customClass="HeaderView">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -201,7 +206,7 @@
                         </view>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cell" rowHeight="43.5" id="DkW-MC-Aab">
-                                <rect key="frame" x="0.0" y="72" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="94" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="DkW-MC-Aab" id="Jfr-f9-6NL">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -243,14 +248,14 @@
             <objects>
                 <viewController title="Font Details" id="B8B-CA-WOL" customClass="DetailViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="xsj-C1-MrB">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eXb-6o-J85">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="t9v-2L-JtN">
-                                        <rect key="frame" x="0.0" y="20" width="414" height="823.5"/>
+                                        <rect key="frame" x="0.0" y="20" width="414" height="757.5"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7cn-Q4-QXT">
                                                 <rect key="frame" x="20" y="0.0" width="374" height="40"/>
@@ -296,7 +301,7 @@
                                                 <subviews>
                                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" verticalHuggingPriority="750" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" editable="NO" textAlignment="center" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m7S-bd-HG1">
                                                         <rect key="frame" x="10" y="10" width="354" height="252.5"/>
-                                                        <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="backgroundColor" systemColor="secondarySystemBackgroundColor"/>
                                                         <string key="text">ABCDEFGHIJKLM
 NOPQRSTUVWXYZ
 abcdefghijklm
@@ -307,12 +312,12 @@ nopqrstuvwxyz
 Hamburgfonstiv
 
 How razorback-jumping frogs can level six piqued gymnasts!</string>
-                                                        <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                        <color key="textColor" systemColor="labelColor"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                     </textView>
                                                 </subviews>
-                                                <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="backgroundColor" systemColor="secondarySystemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstItem="m7S-bd-HG1" firstAttribute="leading" secondItem="Ivc-Tp-xMC" secondAttribute="leading" constant="10" id="DcK-sn-dGT"/>
                                                     <constraint firstAttribute="bottom" secondItem="m7S-bd-HG1" secondAttribute="bottom" constant="10" id="Vmk-WT-4qL"/>
@@ -322,7 +327,7 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CgR-CW-xgK">
                                                 <rect key="frame" x="202" y="332.5" width="10" height="10"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="10" id="b7d-YK-6cF"/>
                                                     <constraint firstAttribute="width" constant="10" id="m1q-rF-OEu"/>
@@ -332,13 +337,13 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                                 <rect key="frame" x="20" y="352.5" width="374" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="File Name" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7fK-Pn-QLd">
-                                                        <rect key="frame" x="0.0" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MyFont.ttf" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6zX-ej-UMU">
-                                                        <rect key="frame" x="192" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="89" y="0.0" width="285" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -349,13 +354,13 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                                 <rect key="frame" x="20" y="383" width="374" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="PostScript Name" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AzZ-Uv-yGl">
-                                                        <rect key="frame" x="0.0" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MyFont-Regular" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aNI-lC-f2f">
-                                                        <rect key="frame" x="192" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="89" y="0.0" width="285" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -366,13 +371,13 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                                 <rect key="frame" x="20" y="413.5" width="374" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="Full Name" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5GB-6w-QAj">
-                                                        <rect key="frame" x="0.0" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="My Font Regular" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gDe-ex-bBn">
-                                                        <rect key="frame" x="192" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="89" y="0.0" width="285" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -383,13 +388,13 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                                 <rect key="frame" x="20" y="444" width="374" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="Family" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="esG-gg-dKM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="My Font" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7FM-tz-szw">
-                                                        <rect key="frame" x="192" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="89" y="0.0" width="285" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -400,13 +405,13 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                                 <rect key="frame" x="20" y="474.5" width="374" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="Style" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bhU-gW-MFj">
-                                                        <rect key="frame" x="0.0" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Regular" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="az5-rx-TYU">
-                                                        <rect key="frame" x="192" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="89" y="0.0" width="285" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -417,13 +422,13 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                                 <rect key="frame" x="20" y="505" width="374" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="Monospaced" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i3h-tF-FFh">
-                                                        <rect key="frame" x="0.0" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HsY-i3-sNc">
-                                                        <rect key="frame" x="192" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="89" y="0.0" width="285" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -434,13 +439,13 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                                 <rect key="frame" x="20" y="535.5" width="374" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="Glyph Count" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DOi-Ta-eJi">
-                                                        <rect key="frame" x="0.0" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1,234" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rDj-RZ-xi1">
-                                                        <rect key="frame" x="192" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="89" y="0.0" width="285" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -451,13 +456,13 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                                 <rect key="frame" x="20" y="566" width="374" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="Version" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gXQ-TC-9Rw">
-                                                        <rect key="frame" x="0.0" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1.0a1" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nSd-dV-SL4">
-                                                        <rect key="frame" x="192" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="89" y="0.0" width="285" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -468,13 +473,13 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                                 <rect key="frame" x="20" y="596.5" width="374" height="42.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="Copyright" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b0l-a4-B57">
-                                                        <rect key="frame" x="0.0" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="© Some Company with a Long Name, Inc." textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Has-Tl-Ky7">
-                                                        <rect key="frame" x="192" y="0.0" width="182" height="42.5"/>
+                                                        <rect key="frame" x="89" y="0.0" width="285" height="42.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -482,16 +487,16 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="era-WV-WYr">
-                                                <rect key="frame" x="20" y="649" width="374" height="174.5"/>
+                                                <rect key="frame" x="20" y="649" width="374" height="108.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Description" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kVe-yk-J3E">
-                                                        <rect key="frame" x="0.0" y="0.0" width="182" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eYp-bL-u5D">
-                                                        <rect key="frame" x="192" y="0.0" width="182" height="174.5"/>
+                                                        <rect key="frame" x="89" y="0.0" width="285" height="108.5"/>
                                                         <string key="text">This is going to either be really short (or non-existant) or a fricken' tomb on the font's history. It all depends on the foundary and the motivations behind the designers.</string>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
@@ -548,14 +553,14 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                 <viewLayoutGuide key="frameLayoutGuide" id="Kph-h8-puE"/>
                             </scrollView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="l7r-hR-fmf"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="l7r-hR-fmf" firstAttribute="trailing" secondItem="eXb-6o-J85" secondAttribute="trailing" id="Ury-uw-gZN"/>
                             <constraint firstItem="eXb-6o-J85" firstAttribute="top" secondItem="xsj-C1-MrB" secondAttribute="top" id="aDS-Kb-dDO"/>
                             <constraint firstItem="eXb-6o-J85" firstAttribute="leading" secondItem="l7r-hR-fmf" secondAttribute="leading" id="uH5-D6-IJE"/>
                             <constraint firstAttribute="bottom" secondItem="eXb-6o-J85" secondAttribute="bottom" id="yFF-Sf-Thk"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="l7r-hR-fmf"/>
                     </view>
                     <navigationItem key="navigationItem" title="Details" id="UFN-za-ye9"/>
                     <connections>
@@ -609,8 +614,8 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                 <navigationController id="PaN-a1-ZQu" customClass="NavigationController" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Help" image="book" catalog="system" selectedImage="book.fill" id="mSk-N8-bCf"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" id="ueB-LF-Fhc">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="ueB-LF-Fhc">
+                        <rect key="frame" x="0.0" y="96" width="414" height="54"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" name="appHeaderTint"/>
                         <color key="barTintColor" name="appHeaderBackground"/>
@@ -631,19 +636,19 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
             <objects>
                 <viewController id="CFk-UM-8KU" customClass="HelpViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="frl-PP-akL">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" contentInsetAdjustmentBehavior="always" editable="NO" usesAttributedText="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QjW-Pk-7rf">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="lessThanOrEqual" constant="500" id="Lpj-2M-y85"/>
                                 </constraints>
                                 <attributedString key="attributedText">
                                     <fragment content="Explain why this app is both dangerous and necessary.">
                                         <attributes>
-                                            <color key="NSColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="NSColor" systemColor="labelColor"/>
                                             <font key="NSFont" metaFont="system" size="17"/>
                                         </attributes>
                                     </fragment>
@@ -651,7 +656,8 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="bu9-yP-IYN"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="QjW-Pk-7rf" firstAttribute="top" secondItem="frl-PP-akL" secondAttribute="top" id="Geo-9n-W0a"/>
                             <constraint firstItem="bu9-yP-IYN" firstAttribute="trailing" secondItem="QjW-Pk-7rf" secondAttribute="trailing" priority="750" id="IUl-Ug-JIT"/>
@@ -659,7 +665,6 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
                             <constraint firstAttribute="bottom" secondItem="QjW-Pk-7rf" secondAttribute="bottom" id="i6y-at-7px"/>
                             <constraint firstItem="QjW-Pk-7rf" firstAttribute="centerX" secondItem="bu9-yP-IYN" secondAttribute="centerX" id="nxk-Oy-IUp"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="bu9-yP-IYN"/>
                     </view>
                     <navigationItem key="navigationItem" title="Help" id="5y7-tJ-82J"/>
                     <connections>
@@ -675,24 +680,24 @@ How razorback-jumping frogs can level six piqued gymnasts!</string>
             <objects>
                 <viewController id="512-d6-5g3" customClass="AboutViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="TGN-Fy-Bhh">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" image="product_logo" translatesAutoresizingMaskIntoConstraints="NO" id="ssB-O3-fKC">
-                                <rect key="frame" x="82" y="141" width="250" height="54.5"/>
+                                <rect key="frame" x="82" y="217.5" width="250" height="54.5"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="250" id="PHv-T6-emz"/>
                                     <constraint firstAttribute="width" secondItem="ssB-O3-fKC" secondAttribute="height" multiplier="1550:340" id="mhX-3v-yfw"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Created by" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EaN-Ap-foU">
-                                <rect key="frame" x="167" y="215.5" width="80" height="19.5"/>
+                                <rect key="frame" x="167" y="292" width="80" height="19.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                 <color key="textColor" name="infoHighightSecondary"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rF5-M2-9bK">
-                                <rect key="frame" x="139" y="243" width="136.5" height="57.5"/>
+                                <rect key="frame" x="139" y="319.5" width="136.5" height="57.5"/>
                                 <string key="text">Manolo Sañudo
 Craig Hockenberry
 Gedeon Maheux</string>
@@ -701,28 +706,29 @@ Gedeon Maheux</string>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="iconfactory_logo" translatesAutoresizingMaskIntoConstraints="NO" id="OEy-Nw-MIH">
-                                <rect key="frame" x="191" y="495.5" width="32" height="32"/>
+                                <rect key="frame" x="191" y="648.5" width="32" height="32"/>
                                 <color key="tintColor" name="infoHighightSecondary"/>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="design by the iconfactory" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UMc-xU-7A4">
-                                <rect key="frame" x="125" y="535.5" width="164" height="17"/>
+                                <rect key="frame" x="125" y="688.5" width="164" height="17"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" name="infoHighightSecondary"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="POK-iA-bdr">
-                                <rect key="frame" x="125" y="495.5" width="164" height="57"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="POK-iA-bdr">
+                                <rect key="frame" x="125" y="648.5" width="164" height="57"/>
                                 <connections>
                                     <action selector="openIconfactory:" destination="512-d6-5g3" eventType="touchUpInside" id="4BP-z7-39j"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="VERSION 1.0 (123)" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aV2-e9-TtV">
-                                <rect key="frame" x="158.5" y="592.5" width="97" height="13.5"/>
+                                <rect key="frame" x="158.5" y="745.5" width="97" height="13.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                 <color key="textColor" name="infoHighightSecondary"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="Kwx-xM-UQ5"/>
                         <color key="backgroundColor" name="infoBackground"/>
                         <constraints>
                             <constraint firstItem="ssB-O3-fKC" firstAttribute="centerX" secondItem="rF5-M2-9bK" secondAttribute="centerX" id="0TK-dU-4No"/>
@@ -744,7 +750,6 @@ Gedeon Maheux</string>
                             <constraint firstItem="EaN-Ap-foU" firstAttribute="top" secondItem="ssB-O3-fKC" secondAttribute="bottom" constant="20" id="tJa-Bs-nTf"/>
                             <constraint firstItem="UMc-xU-7A4" firstAttribute="top" secondItem="OEy-Nw-MIH" secondAttribute="bottom" constant="8" id="wYv-xT-iza"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="Kwx-xM-UQ5"/>
                     </view>
                     <navigationItem key="navigationItem" title="About" id="1LR-fx-030"/>
                     <connections>
@@ -782,8 +787,8 @@ Gedeon Maheux</string>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="ojk-Bn-Ctu" customClass="NavigationController" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Fonts" image="textformat" catalog="system" id="nEz-5w-u7v"/>
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="6P9-P3-wLF">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="6P9-P3-wLF">
+                        <rect key="frame" x="0.0" y="96" width="414" height="54"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" name="appHeaderTint"/>
                         <color key="barTintColor" name="appHeaderBackground"/>
@@ -806,13 +811,13 @@ Gedeon Maheux</string>
                 <navigationController id="wln-UC-LOP" customClass="NavigationController" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="About" image="info.circle" catalog="system" selectedImage="info.circle.fill" id="Egl-p3-48L"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" id="CKL-BM-BvV">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="CKL-BM-BvV">
+                        <rect key="frame" x="0.0" y="96" width="414" height="54"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" name="appHeaderTint"/>
                         <color key="barTintColor" name="appHeaderBackground"/>
                         <textAttributes key="titleTextAttributes">
-                            <color key="textColor" name="appHeaderText"/>
+                            <color key="textColor" name="infoHighlight"/>
                         </textAttributes>
                     </navigationBar>
                     <connections>
@@ -826,20 +831,20 @@ Gedeon Maheux</string>
     </scenes>
     <color key="tintColor" name="appTint"/>
     <resources>
-        <image name="arrow.down.circle.fill" catalog="system" width="128" height="121"/>
+        <image name="arrow.down.circle.fill" catalog="system" width="128" height="123"/>
         <image name="arrowhead" width="12" height="12"/>
-        <image name="book" catalog="system" width="128" height="101"/>
-        <image name="book.fill" catalog="system" width="128" height="100"/>
+        <image name="book" catalog="system" width="128" height="99"/>
+        <image name="book.fill" catalog="system" width="128" height="95"/>
         <image name="iconfactory_logo" width="32" height="32"/>
-        <image name="info.circle" catalog="system" width="128" height="121"/>
-        <image name="info.circle.fill" catalog="system" width="128" height="121"/>
+        <image name="info.circle" catalog="system" width="128" height="123"/>
+        <image name="info.circle.fill" catalog="system" width="128" height="123"/>
         <image name="product_logo" width="775" height="170"/>
-        <image name="textformat" catalog="system" width="128" height="80"/>
+        <image name="textformat" catalog="system" width="128" height="78"/>
         <namedColor name="appHeaderBackground">
             <color red="0.62745098039215685" green="0.52549019607843139" blue="0.8666666666666667" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="appHeaderText">
-            <color red="0.94509803921568625" green="0.92549019607843142" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.46666666666666667" green="0.35686274509803922" blue="0.72941176470588232" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="appHeaderTint">
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -862,5 +867,14 @@ Gedeon Maheux</string>
         <namedColor name="statusTextSecondary">
             <color red="1" green="1" blue="1" alpha="0.75" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="secondarySystemBackgroundColor">
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/xFonts/Base.lproj/Main.storyboard
+++ b/xFonts/Base.lproj/Main.storyboard
@@ -727,6 +727,13 @@ Gedeon Maheux</string>
                                 <color key="textColor" name="infoHighightSecondary"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Wdv-hT-hBa">
+                                <rect key="frame" x="0.0" y="779" width="414" height="200"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="200" id="0Hk-W9-yzp"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Kwx-xM-UQ5"/>
                         <color key="backgroundColor" name="infoBackground"/>
@@ -735,6 +742,7 @@ Gedeon Maheux</string>
                             <constraint firstItem="rF5-M2-9bK" firstAttribute="centerX" secondItem="Kwx-xM-UQ5" secondAttribute="centerX" id="9yH-RJ-0Go"/>
                             <constraint firstItem="aV2-e9-TtV" firstAttribute="centerX" secondItem="Kwx-xM-UQ5" secondAttribute="centerX" id="BwE-vC-i0A"/>
                             <constraint firstItem="rF5-M2-9bK" firstAttribute="top" secondItem="EaN-Ap-foU" secondAttribute="bottom" constant="8" id="Bze-3X-SAM"/>
+                            <constraint firstItem="Kwx-xM-UQ5" firstAttribute="trailing" secondItem="Wdv-hT-hBa" secondAttribute="trailing" id="CG2-Qu-Yu5"/>
                             <constraint firstItem="rF5-M2-9bK" firstAttribute="centerY" secondItem="Kwx-xM-UQ5" secondAttribute="centerY" multiplier="0.75" priority="750" id="DTe-gZ-284"/>
                             <constraint firstItem="POK-iA-bdr" firstAttribute="top" secondItem="OEy-Nw-MIH" secondAttribute="top" id="Fdg-yK-Hgh"/>
                             <constraint firstItem="aV2-e9-TtV" firstAttribute="top" secondItem="UMc-xU-7A4" secondAttribute="bottom" constant="40" id="Fya-2a-l10"/>
@@ -744,8 +752,10 @@ Gedeon Maheux</string>
                             <constraint firstItem="UMc-xU-7A4" firstAttribute="centerX" secondItem="aV2-e9-TtV" secondAttribute="centerX" id="aRA-dZ-uii"/>
                             <constraint firstItem="OEy-Nw-MIH" firstAttribute="centerX" secondItem="UMc-xU-7A4" secondAttribute="centerX" id="coJ-CE-6Vo"/>
                             <constraint firstItem="EaN-Ap-foU" firstAttribute="centerX" secondItem="Kwx-xM-UQ5" secondAttribute="centerX" id="dqf-6U-hfZ"/>
+                            <constraint firstItem="Wdv-hT-hBa" firstAttribute="top" secondItem="Kwx-xM-UQ5" secondAttribute="bottom" id="fEr-nv-Dp9"/>
                             <constraint firstItem="POK-iA-bdr" firstAttribute="trailing" secondItem="UMc-xU-7A4" secondAttribute="trailing" id="j3V-Ko-gz6"/>
                             <constraint firstItem="POK-iA-bdr" firstAttribute="bottom" secondItem="UMc-xU-7A4" secondAttribute="bottom" id="rAF-DG-arj"/>
+                            <constraint firstItem="Wdv-hT-hBa" firstAttribute="leading" secondItem="Kwx-xM-UQ5" secondAttribute="leading" id="sBT-Ch-GDO"/>
                             <constraint firstItem="Kwx-xM-UQ5" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="aV2-e9-TtV" secondAttribute="bottom" constant="10" id="sfj-6L-WPm"/>
                             <constraint firstItem="EaN-Ap-foU" firstAttribute="top" secondItem="ssB-O3-fKC" secondAttribute="bottom" constant="20" id="tJa-Bs-nTf"/>
                             <constraint firstItem="UMc-xU-7A4" firstAttribute="top" secondItem="OEy-Nw-MIH" secondAttribute="bottom" constant="8" id="wYv-xT-iza"/>
@@ -753,6 +763,7 @@ Gedeon Maheux</string>
                     </view>
                     <navigationItem key="navigationItem" title="About" id="1LR-fx-030"/>
                     <connections>
+                        <outlet property="tabBarBackgroundView" destination="Wdv-hT-hBa" id="bYX-nI-n2c"/>
                         <outlet property="versionLabel" destination="aV2-e9-TtV" id="ixu-En-Gqj"/>
                     </connections>
                 </viewController>
@@ -871,7 +882,7 @@ Gedeon Maheux</string>
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="secondarySystemBackgroundColor">
-            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/xFonts/DetailViewController.m
+++ b/xFonts/DetailViewController.m
@@ -37,7 +37,6 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    // Do any additional setup after loading the view.
 	
 	[self updateView];
 }

--- a/xFonts/DetailViewController.m
+++ b/xFonts/DetailViewController.m
@@ -42,16 +42,6 @@
 	[self updateView];
 }
 
-/*
-#pragma mark - Navigation
-
-// In a storyboard-based application, you will often want to do a little preparation before navigation
-- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    // Get the new view controller using [segue destinationViewController].
-    // Pass the selected object to the new view controller.
-}
-*/
-
 #pragma mark - Utility
 
 - (void)updateView

--- a/xFonts/HelpOverlayViewController.h
+++ b/xFonts/HelpOverlayViewController.h
@@ -1,0 +1,17 @@
+//
+//  HelpOverlayViewController.h
+//  xFonts
+//
+//  Created by manolo on 9/20/25.
+//  Copyright © 2025 manolo. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface HelpOverlayViewController : UIViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/xFonts/HelpOverlayViewController.m
+++ b/xFonts/HelpOverlayViewController.m
@@ -1,0 +1,27 @@
+//
+//  HelpOverlayViewController.m
+//  xFonts
+//
+//  Created by manolo on 9/20/25.
+//  Copyright © 2025 manolo. All rights reserved.
+//
+
+#import "HelpOverlayViewController.h"
+
+@interface HelpOverlayViewController ()
+
+@property (nonatomic, weak) IBOutlet UIButton *okButton;
+
+@end
+
+@implementation HelpOverlayViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+	
+	if (@available(iOS 26.0, *)) {
+		[self.okButton setConfiguration:UIButtonConfiguration.prominentGlassButtonConfiguration];
+	}
+}
+
+@end

--- a/xFonts/HelpViewController.m
+++ b/xFonts/HelpViewController.m
@@ -33,16 +33,6 @@
 	[self.textView scrollRangeToVisible:NSMakeRange(0, 0)];
 }
 
-/*
-#pragma mark - Navigation
-
-// In a storyboard-based application, you will often want to do a little preparation before navigation
-- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    // Get the new view controller using [segue destinationViewController].
-    // Pass the selected object to the new view controller.
-}
-*/
-
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
 {
 	DebugLog(@"%s called", __PRETTY_FUNCTION__);

--- a/xFonts/MarkdownAttributedString/NSAttributedString+Markdown.m
+++ b/xFonts/MarkdownAttributedString/NSAttributedString+Markdown.m
@@ -591,7 +591,7 @@ static void removeEscapesInAttributedString(NSMutableAttributedString *result, N
 
 #pragma mark -
 
-NS_INLINE NSRange emptyRange()
+NS_INLINE NSRange emptyRange(void)
 {
 	return NSMakeRange(NSNotFound, 0);
 }

--- a/xFonts/ViewController.m
+++ b/xFonts/ViewController.m
@@ -36,6 +36,11 @@
 
 	DebugLog(@"%s font storage path = '%@'", __PRETTY_FUNCTION__, FontInfo.storageURL.path);
 	
+	if (@available(iOS 26.0, *)) { /* only need to change the color before iOS 26 */ } else {
+		[self.installButton setTintColor:[UIColor colorNamed:@"appHeaderText"]];
+		[self.addButton setTintColor:[UIColor colorNamed:@"appHeaderText"]];
+	}
+	
 	NSNotificationCenter *notificationCenter = NSNotificationCenter.defaultCenter;
 	[notificationCenter addObserver:self selector:@selector(applicationDidEnterBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
 	[notificationCenter addObserver:self selector:@selector(applicationDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];


### PR DESCRIPTION
minor color tweaks for buttons in iOS 26 and other Xcode project updates
also fixed the titles for the font details view

| home screen |
| --- |
| <img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-24 at 17 01 27" src="https://github.com/user-attachments/assets/128f448a-7766-4d2c-a1b2-52749cbcd0ec" /> |
